### PR TITLE
chore(tooling): migrate to github actions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,7 +38,7 @@ jobs:
         dotnet-version: 9.0.x
 
     - name: Build the app
-      run: dotnet build --configuration $env:Configuration -p:Version=$(VERSION);FileVersion=$(VERSION)
+      run: dotnet build --configuration $env:Configuration -p:Version=${{ env.VERSION }};FileVersion=${{ env.VERSION }}
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,7 +38,7 @@ jobs:
         dotnet-version: 9.0.x
 
     - name: Build the app
-      run: dotnet build --configuration $env:Configuration -p:Version=${{ env.VERSION }};FileVersion=${{ env.VERSION }}
+      run: dotnet build --configuration $env:Configuration -p:Version=${{ env.VERSION }} -p:FileVersion=${{ env.VERSION }}
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -34,6 +34,8 @@ jobs:
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
+      with:
+        vs-prerelease: true
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application
@@ -60,7 +62,7 @@ jobs:
         # path to folder containing files to sign.
         folder: 'OotD.Launcher\bin\Release\net9.0-windows7.0'
         # Recursively search for supported files.
-        recursive: 'true'
+        recursive: true
         # URL of the timestamp server used for the signing
         timestamp-server: 'http://timestamp.digicert.com'
               

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         Configuration: ${{ matrix.configuration }}
 
-    - name: Sign the application
+    - name: Sign App Files
       uses: GabrielAcostaEngler/signtool-code-sign@1.0.6
       with:
         certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
@@ -50,10 +50,21 @@ jobs:
       uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
       with:
         path: "Setup Script.iss"
-        options: /O+        
+        options: /O+
+        
+    - name: Sign Installer
+      uses: GabrielAcostaEngler/signtool-code-sign@1.0.6
+      with:
+        certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
+        cert-password: '${{ secrets.PFX_PASSWORD }}'
+        cert-sha1: '${{ secrets.CERT_HASH_SHA1 }}'
+        # path to folder containing files to sign.
+        folder: 'ServerStaging'
+        recursive: false
+        timestamp-server: 'http://timestamp.digicert.com'        
 
-    #- name: Upload build artifacts
-    #  uses: actions/upload-artifact@v3
-    #  with:
-    #    name: MSIX Package
-    #    path: ${{ env.Wap_Project_Directory }}\AppPackages
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Installer
+        path: ServerStaging

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -25,22 +25,13 @@ jobs:
         submodules: 'true'
         fetch-depth: 0
 
-    # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:        
         dotnet-version: 9.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-prerelease: true
-        vs-version: '[17.12]'
-
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      run: dotnet build --configuration $env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,4 @@
-name: .NET Core Desktop
+name: Build and Sign
 
 on:
   push:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,0 +1,75 @@
+name: .NET Core Desktop
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    runs-on: windows-latest
+    
+    env:
+      Solution_Name: OutlookDesktop.sln
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+        fetch-depth: 0
+
+    # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v4
+      with:        
+        dotnet-version: 9.0.x
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v2
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Decode the base 64 encoded pfx and save the Signing_Certificate
+    - name: Decode the pfx
+      run: |
+        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.BASE64_ENCODED_PFX }}")
+        $certificatePath = Join-Path -Path . -ChildPath ootd.pfx
+        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+
+    - name: Signtool Code Sign
+      uses: GabrielAcostaEngler/signtool-code-sign@1.0.6
+      with:
+        # Base64 encoded pfx certificate
+        certificate: 'ootd.pfx'
+        # Certificate password
+        cert-password: '{{ secrets.PFX_PASSWORD }}'
+        # Certificate sha1/thumbprint
+        cert-sha1: 'ED:0B:B3:52:10:CF:BE:8A:04:E7:97:67:D0:2A:1C:9A:51:0C:9C:39'
+        # path to folder containing files to sign.
+        folder: 'OotD.Launcher\bin\Release\net9.0-windows7.0'
+        # Recursively search for supported files.
+        recursive: 'true'
+        # URL of the timestamp server used for the signing
+        timestamp-server: 'http://timestamp.digicert.com'
+              
+    # Remove the pfx
+    - name: Remove the pfx
+      run: Remove-Item -path ootd.pfx
+
+    #- name: Upload build artifacts
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: MSIX Package
+    #    path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -16,9 +16,16 @@ jobs:
     runs-on: windows-latest
     
     env:
-      Solution_Name: OutlookDesktop.sln
+     VERSION: '4.3.${{ github.run_number }}'
 
     steps:
+    - name: Output Run ID
+      run: echo ${{ github.run_id }}
+    - name: Output Run Number
+      run: echo ${{ github.run_number }}
+    - name: Output Run Attempt
+      run: echo ${{ github.run_attempt }}
+    
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -31,7 +38,7 @@ jobs:
         dotnet-version: 9.0.x
 
     - name: Build the app
-      run: dotnet build --configuration $env:Configuration
+      run: dotnet build --configuration $env:Configuration -p:Version=$(MAJOR_MINOR_VERSION);FileVersion=$(MAJOR_MINOR_VERSION)
       env:
         Configuration: ${{ matrix.configuration }}
 
@@ -43,9 +50,7 @@ jobs:
         cert-sha1: '${{ secrets.CERT_HASH_SHA1 }}'
         # path to folder containing files to sign.
         folder: 'OotD.Launcher\bin\Release\net9.0-windows7.0'
-        # Recursively search for supported files.
         recursive: true
-        # URL of the timestamp server used for the signing
         timestamp-server: 'http://timestamp.digicert.com'
 
     - name: Build Installer

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -18,14 +18,7 @@ jobs:
     env:
      VERSION: '4.3.${{ github.run_number }}'
 
-    steps:
-    - name: Output Run ID
-      run: echo ${{ github.run_id }}
-    - name: Output Run Number
-      run: echo ${{ github.run_number }}
-    - name: Output Run Attempt
-      run: echo ${{ github.run_attempt }}
-    
+    steps:    
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,7 +38,7 @@ jobs:
         dotnet-version: 9.0.x
 
     - name: Build the app
-      run: dotnet build --configuration $env:Configuration -p:Version=$(MAJOR_MINOR_VERSION);FileVersion=$(MAJOR_MINOR_VERSION)
+      run: dotnet build --configuration $env:Configuration -p:Version=$(VERSION);FileVersion=$(VERSION)
       env:
         Configuration: ${{ matrix.configuration }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -36,6 +36,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
       with:
         vs-prerelease: true
+        vs-version: '[17.12]'
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        configuration: [Release]
 
     runs-on: windows-latest
     
@@ -30,27 +30,17 @@ jobs:
       with:        
         dotnet-version: 9.0.x
 
-    - name: Restore the application
+    - name: Build the app
       run: dotnet build --configuration $env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 
-    # Decode the base 64 encoded pfx and save the Signing_Certificate
-    - name: Decode the pfx
-      run: |
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.BASE64_ENCODED_PFX }}")
-        $certificatePath = Join-Path -Path . -ChildPath ootd.pfx
-        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
-
-    - name: Signtool Code Sign
+    - name: Sign the application
       uses: GabrielAcostaEngler/signtool-code-sign@1.0.6
       with:
-        # Base64 encoded pfx certificate
-        certificate: 'ootd.pfx'
-        # Certificate password
-        cert-password: '{{ secrets.PFX_PASSWORD }}'
-        # Certificate sha1/thumbprint
-        cert-sha1: 'ED:0B:B3:52:10:CF:BE:8A:04:E7:97:67:D0:2A:1C:9A:51:0C:9C:39'
+        certificate: '${{ secrets.BASE64_ENCODED_PFX }}'
+        cert-password: '${{ secrets.PFX_PASSWORD }}'
+        cert-sha1: '${{ secrets.CERT_HASH_SHA1 }}'
         # path to folder containing files to sign.
         folder: 'OotD.Launcher\bin\Release\net9.0-windows7.0'
         # Recursively search for supported files.

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -47,10 +47,12 @@ jobs:
         recursive: true
         # URL of the timestamp server used for the signing
         timestamp-server: 'http://timestamp.digicert.com'
-              
-    # Remove the pfx
-    - name: Remove the pfx
-      run: Remove-Item -path ootd.pfx
+
+    - name: Build Installer
+      uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+      with:
+        path: "Setup Script.iss"
+        options: /O+        
 
     #- name: Upload build artifacts
     #  uses: actions/upload-artifact@v3


### PR DESCRIPTION
This creates a new GHA workflow to build and sign the app and upload artifacts. Will replace the Azure Devops workflow eventually.