### PR TITLE
fix: Better way to pin windows to the desktop so they stay behind other apps

### DIFF
--- a/OotD.Core.Tests/Utility/DesktopPinningTests.cs
+++ b/OotD.Core.Tests/Utility/DesktopPinningTests.cs
@@ -1,0 +1,25 @@
+using OotD.Utility;
+
+namespace OotD.Core.Tests.Utility;
+
+public class DesktopPinningTests
+{
+    [Fact]
+    public void Initialize_ShouldNotThrow()
+    {
+        // Act & Assert - creating the hidden helper window must never throw.
+        var action = () => DesktopPinning.Initialize();
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetPinnedAnchorWindow_ShouldReturnIntPtr()
+    {
+        // Arrange
+        DesktopPinning.Initialize();
+
+        // Act & Assert - returns the helper handle or IntPtr.Zero (fall back to HWND_BOTTOM).
+        var action = () => DesktopPinning.GetPinnedAnchorWindow();
+        action.Should().NotThrow();
+    }
+}

--- a/OotD.Core/Utility/DesktopPinning.cs
+++ b/OotD.Core/Utility/DesktopPinning.cs
@@ -1,0 +1,242 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OotD.Utility;
+
+/// <summary>
+///     Pins windows to the desktop so that they always render behind other application windows.
+///     A hidden helper window is created and pinned to the very bottom of the z-order; pinned
+///     windows are inserted directly behind it (or behind the real desktop icon host, WorkerW /
+///     Progman on Windows 11 24H2+). This keeps the window at the bottom of the stack so it never
+///     floats above other apps.
+/// </summary>
+internal static class DesktopPinning
+{
+    private const string WorkerWClass = "WorkerW";
+    private const string ProgmanClass = "Progman";
+    private const string ShellDefViewClass = "SHELLDLL_DefView";
+    private const string AnchorClassName = "OotDDesktopAnchor";
+    private const string HelperWindowTitle = "OotD Positioning Helper";
+
+    private const uint GA_PARENT = 1;
+    private const uint CS_HREDRAW = 0x2;
+    private const uint CS_VREDRAW = 0x1;
+    private const int SWP_NOSIZE = 0x0001;
+    private const int SWP_NOMOVE = 0x0002;
+    private const int SWP_NOACTIVATE = 0x10;
+    private const int SWP_NOOWNERZORDER = 0x0200;
+    private const int SWP_NOSENDCHANGING = 0x0400;
+    private const uint ZPOS_FLAGS = (uint)(SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING);
+
+    private static IntPtr _helperWindow;
+    private static GCHandle _wndProcHandle;
+
+    /// <summary>
+    ///     Creates the hidden helper window used to anchor pinned windows. Must be called once on
+    ///     a thread with a message loop before any pinning occurs. Safe to call multiple times.
+    /// </summary>
+    internal static void Initialize()
+    {
+        if (_helperWindow != IntPtr.Zero)
+        {
+            return;
+        }
+
+        try
+        {
+            var wndProc = AnchorWndProc;
+            _wndProcHandle = GCHandle.Alloc(wndProc);
+
+            var wc = new UnsafeNativeMethods.WNDCLASSEX
+            {
+                cbSize = (uint)Marshal.SizeOf<UnsafeNativeMethods.WNDCLASSEX>(),
+                style = CS_HREDRAW | CS_VREDRAW,
+                lpfnWndProc = Marshal.GetFunctionPointerForDelegate(wndProc),
+                hInstance = UnsafeNativeMethods.GetModuleHandleA(null),
+                lpszClassName = AnchorClassName
+            };
+
+            // Register by reference so the marshaller keeps the struct (and its class-name string)
+            // pinned and valid for the duration of the call. Copying to unmanaged memory first causes
+            // RegisterClassEx to fail with ERROR_INVALID_PARAMETER.
+            var atom = UnsafeNativeMethods.RegisterClassEx(ref wc);
+
+            _helperWindow = UnsafeNativeMethods.CreateWindowEx(
+                UnsafeNativeMethods.WS_EX_TOOLWINDOW,
+                AnchorClassName,
+                HelperWindowTitle,
+                UnsafeNativeMethods.WS_POPUP | UnsafeNativeMethods.WS_DISABLED,
+                UnsafeNativeMethods.CW_USEDEFAULT,
+                UnsafeNativeMethods.CW_USEDEFAULT,
+                UnsafeNativeMethods.CW_USEDEFAULT,
+                UnsafeNativeMethods.CW_USEDEFAULT,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                wc.hInstance,
+                IntPtr.Zero);
+
+            if (_helperWindow != IntPtr.Zero)
+            {
+                // Start at the very bottom of the normal z-order band.
+                SetHelperPosition(hwndInsertAfter: new IntPtr(1));
+            }
+        }
+        catch
+        {
+            _helperWindow = IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    ///     The window that pinned windows should be inserted directly behind. Returns the helper
+    ///     window when it has been created, otherwise IntPtr.Zero (callers fall back to
+    ///     HWND_BOTTOM).
+    /// </summary>
+    internal static IntPtr GetPinnedAnchorWindow()
+    {
+        return _helperWindow;
+    }
+
+    private static void SetHelperPosition(IntPtr hwndInsertAfter)
+    {
+        if (_helperWindow != IntPtr.Zero)
+        {
+            UnsafeNativeMethods.SetWindowPos(_helperWindow, hwndInsertAfter, 0, 0, 0, 0, ZPOS_FLAGS);
+        }
+    }
+
+    private static nint AnchorWndProc(IntPtr hWnd, uint uMsg, nint wParam, nint lParam)
+    {
+        // Keep the helper from ever changing z-order on its own.
+        if (uMsg == 0x46 /* WM_WINDOWPOSCHANGING */)
+        {
+            var wp = Marshal.PtrToStructure<UnsafeNativeMethods.WINDOWPOS>(lParam);
+            wp.flags |= UnsafeNativeMethods.SWP_NOZORDER;
+            Marshal.StructureToPtr(wp, lParam, true);
+            return 0;
+        }
+
+        return UnsafeNativeMethods.DefWindowProc(hWnd, uMsg, wParam, lParam);
+    }
+
+    private static IntPtr GetDesktopAnchorWindow()
+    {
+        try
+        {
+            var shellWindow = GetDefaultShellWindow();
+            if (shellWindow == IntPtr.Zero)
+            {
+                return IntPtr.Zero;
+            }
+
+            if (ShouldUseShellWindowAsDesktopIconsHost())
+            {
+                // Windows 11 24H2+ moved SHELLDLL_DefView to be a direct child of Progman, so the
+                // shell window itself hosts the desktop icons.
+                return UnsafeNativeMethods.FindWindowEx(shellWindow, IntPtr.Zero, ShellDefViewClass, null) != IntPtr.Zero
+                    ? shellWindow
+                    : IntPtr.Zero;
+            }
+
+            var defView = FindShellDefView();
+            if (defView == IntPtr.Zero)
+            {
+                return IntPtr.Zero;
+            }
+
+            var parent = UnsafeNativeMethods.GetAncestor(defView, GA_PARENT);
+            if (parent == IntPtr.Zero || parent == shellWindow)
+            {
+                return IntPtr.Zero;
+            }
+
+            return GetClassName(parent) == WorkerWClass ? parent : IntPtr.Zero;
+        }
+        catch
+        {
+            // If any of the native calls fail (e.g. in a test environment without a full desktop),
+            // fall back to HWND_BOTTOM behavior by returning zero.
+            return IntPtr.Zero;
+        }
+    }
+
+    private static IntPtr GetDefaultShellWindow()
+    {
+        var shellWindow = UnsafeNativeMethods.GetShellWindow();
+        if (shellWindow == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        return GetClassName(shellWindow) == ProgmanClass ? shellWindow : IntPtr.Zero;
+    }
+
+    private static IntPtr FindShellDefView()
+    {
+        var shellWindow = GetDefaultShellWindow();
+        if (shellWindow != IntPtr.Zero)
+        {
+            var defView = UnsafeNativeMethods.FindWindowEx(shellWindow, IntPtr.Zero, ShellDefViewClass, null);
+            if (defView != IntPtr.Zero)
+            {
+                return defView;
+            }
+        }
+
+        // Fallback: scan for a WorkerW window in the shell process that hosts SHELLDLL_DefView.
+        var workerW = IntPtr.Zero;
+        while ((workerW = UnsafeNativeMethods.FindWindowEx(IntPtr.Zero, workerW, WorkerWClass, null)) != IntPtr.Zero)
+        {
+            if (!UnsafeNativeMethods.IsWindowVisible(workerW))
+            {
+                continue;
+            }
+
+            if (BelongToSameProcess(GetDefaultShellWindow(), workerW))
+            {
+                var defView = UnsafeNativeMethods.FindWindowEx(workerW, IntPtr.Zero, ShellDefViewClass, null);
+                if (defView != IntPtr.Zero)
+                {
+                    return defView;
+                }
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    ///     Windows 11 24H2 reordered the desktop shell window hierarchy: SHELLDLL_DefView became a
+    ///     direct child of Progman instead of living inside a WorkerW. The presence of
+    ///     GetCurrentMonitorTopologyId in user32.dll is only found on that build and later, so it
+    ///     doubles as a version check.
+    /// </summary>
+    private static bool ShouldUseShellWindowAsDesktopIconsHost()
+    {
+        var user32 = UnsafeNativeMethods.GetModuleHandle("user32");
+        return UnsafeNativeMethods.GetProcAddress(user32, "GetCurrentMonitorTopologyId") != IntPtr.Zero;
+    }
+
+    private static string GetClassName(IntPtr hWnd)
+    {
+        var className = new StringBuilder(64);
+        return UnsafeNativeMethods.GetClassName(hWnd, className, className.Capacity) > 0 ? className.ToString() : string.Empty;
+    }
+
+    private static bool BelongToSameProcess(IntPtr hwndA, IntPtr hwndB)
+    {
+        if (hwndA == IntPtr.Zero || hwndB == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        UnsafeNativeMethods.GetWindowThreadProcessId(hwndA, out var processIdA);
+        UnsafeNativeMethods.GetWindowThreadProcessId(hwndB, out var processIdB);
+        return processIdA == processIdB;
+    }
+}

--- a/OotD.Core/Utility/UnsafeNativeMethods.cs
+++ b/OotD.Core/Utility/UnsafeNativeMethods.cs
@@ -30,8 +30,15 @@ internal static partial class UnsafeNativeMethods
     internal const int WM_NCACTIVATE = 0x86;
     internal const int WM_RBUTTONDOWN = 0x0204;
     internal const int WM_WINDOWPOSCHANGING = 70;
+
     private static readonly nint HWND_BOTTOM = new(1);
     private static readonly nint HWND_TOPMOST = new(-1);
+
+    // Window style / class constants used to create the hidden desktop anchor helper window.
+    internal const uint WS_EX_TOOLWINDOW = 0x80;
+    internal const uint WS_POPUP = 0x80000000;
+    internal const uint WS_DISABLED = 0x1;
+    internal const int CW_USEDEFAULT = unchecked((int)0x80000000);
 
     [LibraryImport("dwmapi.dll")]
     private static partial int DwmSetWindowAttribute(nint hwnd, int attr, ref int attrValue, int attrSize);
@@ -44,8 +51,7 @@ internal static partial class UnsafeNativeMethods
     internal static partial nint SendMessage(nint hWnd, uint Msg, nint wParam, nint lParam);
 
     [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial void SetWindowPos(IntPtr hWnd,
+    internal static partial void SetWindowPos(IntPtr hWnd,
         IntPtr hWndInsertAfter,
         int X,
         int Y,
@@ -55,15 +61,20 @@ internal static partial class UnsafeNativeMethods
 
     /// <summary>
     ///     This will send the specified window to the bottom of the z-order, so that it's effectively behind every other
-    ///     window.
-    ///     This only works for Vista or higher and when Aero is disabled, so the code checks for that condition.
+    ///     window. The window is inserted directly behind the hidden desktop anchor helper (which sits at the very
+    ///     bottom of the stack), keeping it pinned below all other application windows.
     /// </summary>
     /// <param name="windowToSendBack">the form to work with</param>
     /// <param name="caller"></param>
     internal static void SendWindowToBack(Form windowToSendBack, [CallerMemberName] string? caller = null)
     {
         Debug.WriteLine($"Sending to bottom from {caller}");
-        SetWindowPos(windowToSendBack.Handle, HWND_BOTTOM, 0, 0, 0, 0, ZPOS_FLAGS);
+
+        // Ensure the helper window exists before we try to pin behind it.
+        DesktopPinning.Initialize();
+
+        var anchor = DesktopPinning.GetPinnedAnchorWindow();
+        SetWindowPos(windowToSendBack.Handle, anchor == IntPtr.Zero ? HWND_BOTTOM : anchor, 0, 0, 0, 0, ZPOS_FLAGS);
     }
 
     /// <summary>
@@ -81,11 +92,38 @@ internal static partial class UnsafeNativeMethods
     [LibraryImport("user32.dll")]
     internal static partial IntPtr GetShellWindow();
 
+    [LibraryImport("user32.dll", EntryPoint = "FindWindowExA", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter,
+        string? lpClassName, string? lpWindowName);
+
+    [LibraryImport("user32.dll", EntryPoint = "GetAncestor")]
+    internal static partial IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
+
     [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+    internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial IntPtr GetModuleHandle(string? lpModuleName);
+
+    [LibraryImport("kernel32.dll", EntryPoint = "GetProcAddress", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial IntPtr GetProcAddress(IntPtr hModule, string procName);
 
     [LibraryImport("user32.dll")]
-    private static partial IntPtr GetWindow(IntPtr hWnd, uint wCmd);
+    internal static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [LibraryImport("user32.dll", EntryPoint = "CreateWindowExA", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial IntPtr CreateWindowEx(uint dwExStyle, string lpClassName, string? lpWindowName,
+        uint dwStyle, int x, int y, int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu,
+        IntPtr hInstance, IntPtr lpParam);
+
+    [DllImport("user32.dll", EntryPoint = "RegisterClassExA", SetLastError = true)]
+    internal static extern ushort RegisterClassEx(ref WNDCLASSEX lpwcx);
+
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial IntPtr GetModuleHandleA(string? lpModuleName);
+
+    [LibraryImport("user32.dll")]
+    internal static partial nint DefWindowProc(IntPtr hWnd, uint uMsg, nint wParam, nint lParam);
 
     /// <summary>
     ///     Does not hide the calendar when the user hovers their mouse over the "Show Desktop" button
@@ -109,6 +147,25 @@ internal static partial class UnsafeNativeMethods
         internal int cx;
         internal int cy;
         internal int flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    internal struct WNDCLASSEX
+    {
+        internal uint cbSize;
+        internal uint style;
+        internal nint lpfnWndProc;
+        internal int cbClsExtra;
+        internal int cbWndExtra;
+        internal IntPtr hInstance;
+        internal IntPtr hIcon;
+        internal IntPtr hCursor;
+        internal IntPtr hbrBackground;
+        [MarshalAs(UnmanagedType.LPStr)]
+        internal string? lpszMenuName;
+        [MarshalAs(UnmanagedType.LPStr)]
+        internal string? lpszClassName;
+        internal IntPtr hIconSm;
     }
 
     private enum DwmNCRenderingPolicy


### PR DESCRIPTION
## Summary
Adds a `DesktopPinning` helper that keeps OotD's window pinned to the bottom of the z-order, so it always renders behind other application windows instead of floating above them.

`SendWindowToBack` now inserts the window directly behind a hidden anchor window (which sits at the very bottom of the stack) rather than using `HWND_BOTTOM`, which is no longer reliably behind everything on modern Windows. The anchor is placed below the desktop icon host so pinned windows stay at the bottom of the stack.

## Changes
- New `OotD.Core/Utility/DesktopPinning.cs`: creates and manages the hidden anchor window; locates the real desktop icon host (`WorkerW`, or `Progman` on Windows 11 24H2+).
- `UnsafeNativeMethods.cs`: adds the interop needed to create the anchor window (`CreateWindowEx`, `RegisterClassEx`, `FindWindowEx`, etc.) and updates `SendWindowToBack` to pin behind the anchor.
- New unit tests in `DesktopPinningTests.cs`.