### PR TITLE
test: reduce coverage hotspots with testable geometry and menu logic

### DIFF
--- a/OotD.Core.Tests/Forms/InstanceManagerTests.cs
+++ b/OotD.Core.Tests/Forms/InstanceManagerTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.Win32;
 using OotD.Forms;
 using OotD.Preferences;
+using OotD.Properties;
 
 public class InstanceManagerTests : IDisposable
 {
@@ -16,61 +17,22 @@ public class InstanceManagerTests : IDisposable
         PreferencesRegistry.RootPath = _testRootPath;
     }
 
-    [Fact]
-    public void InstanceCount_WithNoRegistryEntries_ShouldReturnZero()
-    {
-        // This test would require mocking the Registry, which is complex
-        // For now, we'll test the logic conceptually
-
-        // Arrange
-        var instanceNames = Array.Empty<string>();
-
-        // Act
-        var count = instanceNames.Count(name => name != "AutoUpdate");
-
-        // Assert
-        count.Should().Be(0);
-    }
-
-    [Fact]
-    public void InstanceCount_WithAutoUpdateOnly_ShouldReturnZero()
-    {
-        // Arrange
-        var instanceNames = new[] { "AutoUpdate" };
-
-        // Act
-        var count = instanceNames.Count(name => name != "AutoUpdate");
-
-        // Assert
-        count.Should().Be(0);
-    }
-
-    [Fact]
-    public void InstanceCount_WithValidInstances_ShouldReturnCorrectCount()
-    {
-        // Arrange
-        var instanceNames = new[] { "Instance1", "Instance2", "AutoUpdate", "Instance3" };
-
-        // Act
-        var count = instanceNames.Count(name => name != "AutoUpdate");
-
-        // Assert
-        count.Should().Be(3);
-    }
-
     [Theory]
     [InlineData(new string[] { }, 0)]
     [InlineData(new[] { "AutoUpdate" }, 0)]
     [InlineData(new[] { "Instance1" }, 1)]
     [InlineData(new[] { "Instance1", "Instance2" }, 2)]
     [InlineData(new[] { "Instance1", "AutoUpdate", "Instance2" }, 2)]
+    [InlineData(new[] { "Instance1", "Instance2", "AutoUpdate", "Instance3" }, 3)]
     public void InstanceCount_WithVariousScenarios_ShouldReturnExpectedCount(string[] instanceNames, int expectedCount)
     {
-        // Act
-        var count = instanceNames.Count(name => name != "AutoUpdate");
+        using var productKey = Registry.CurrentUser.CreateSubKey(ProductRegistryPath);
+        foreach (var instanceName in instanceNames)
+        {
+            productKey.CreateSubKey(instanceName).Dispose();
+        }
 
-        // Assert
-        count.Should().Be(expectedCount);
+        InstanceManager.InstanceCount.Should().Be(expectedCount);
     }
 
     [Fact]
@@ -356,6 +318,158 @@ public class InstanceManagerTests : IDisposable
         // Assert
         menu.Items.Cast<ToolStripItem>().Select(item => item.Name)
             .Should().Equal("CalendarMenu", "InboxMenu");
+    }
+
+    [Fact]
+    public void ConfigureSingleInstanceMenu_RepeatedTransitionsPreserveItemsAndHandlers()
+    {
+        using var menu = CreateInstanceMenu();
+        var clicked = new List<string>();
+        var handlers = new[] { "AddInstanceMenu", "StartWithWindows", "LockPositionMenu", "CheckForUpdatesMenu",
+            "AboutMenu", "ResetConfigMenu" }.ToDictionary(name => name,
+            name => new EventHandler((_, _) => clicked.Add(name)));
+
+        InstanceManager.ConfigureSingleInstanceMenu(menu, handlers);
+        var originalOrder = menu.Items.Cast<ToolStripItem>().Select(item => item.Name).ToArray();
+
+        using var firstSubmenu = InstanceManager.CreateInstanceSubmenu(menu, "Work");
+        using var secondSubmenu = InstanceManager.CreateInstanceSubmenu(menu, "Work");
+        menu.Items.Cast<ToolStripItem>().Count(item => item.Name == "Work").Should().Be(1);
+        menu.Items.Cast<ToolStripItem>().Count(item => item.Name == "AddInstanceSeparator").Should().Be(1);
+        menu.Items["RemoveInstanceMenu"]!.Available.Should().BeTrue();
+        menu.Items["RenameInstanceMenu"]!.Available.Should().BeTrue();
+        menu.Items["ExitMenu"]!.Available.Should().BeFalse();
+        menu.Items["Separator6"]!.Available.Should().BeFalse();
+        menu.Items["Work"]!.BackColor.Should().Be(Color.Gainsboro);
+        secondSubmenu.DropDown.Should().BeSameAs(menu);
+        foreach (var name in handlers.Keys.Where(name => name != "ResetConfigMenu"))
+        {
+            menu.Items[name]!.Available.Should().BeFalse();
+        }
+
+        InstanceManager.ConfigureSingleInstanceMenu(menu, handlers);
+        InstanceManager.ConfigureSingleInstanceMenu(menu, handlers);
+
+        menu.Items.Cast<ToolStripItem>().Select(item => item.Name).Should().Equal(originalOrder);
+        menu.Items["RemoveInstanceMenu"]!.Available.Should().BeFalse();
+        menu.Items["RenameInstanceMenu"]!.Available.Should().BeFalse();
+        menu.Items["ExitMenu"]!.Available.Should().BeTrue();
+        menu.Items["Separator6"]!.Available.Should().BeTrue();
+        foreach (var name in handlers.Keys)
+        {
+            menu.Items[name]!.Available.Should().BeTrue();
+            menu.Items[name]!.PerformClick();
+        }
+
+        clicked.Should().Equal(handlers.Keys);
+    }
+
+    [Fact]
+    public void ConfigureSingleInstanceMenu_PreservesExistingAddItemAndSeparator()
+    {
+        using var menu = CreateInstanceMenu();
+        var clicks = 0;
+        var addItem = new ToolStripMenuItem("Add", null, (_, _) => clicks++, "AddInstanceMenu");
+        var separator = new ToolStripSeparator { Name = "AddInstanceSeparator" };
+        menu.Items.Insert(1, addItem);
+        menu.Items.Insert(2, separator);
+        var handlers = new[] { "StartWithWindows", "LockPositionMenu", "CheckForUpdatesMenu", "AboutMenu",
+            "ResetConfigMenu" }.ToDictionary(name => name, _ => new EventHandler((_, _) => { }));
+
+        InstanceManager.ConfigureSingleInstanceMenu(menu, handlers);
+        InstanceManager.ConfigureSingleInstanceMenu(menu, handlers);
+
+        menu.Items["AddInstanceMenu"].Should().BeSameAs(addItem);
+        menu.Items["AddInstanceSeparator"].Should().BeSameAs(separator);
+        menu.Items.Cast<ToolStripItem>().Count(item => item.Name == "AddInstanceSeparator").Should().Be(1);
+        addItem.PerformClick();
+        clicks.Should().Be(1);
+    }
+
+    [Fact]
+    public void CreateInstanceSubmenu_WithoutSharedItemsAddsHeaderAndSeparatorOnce()
+    {
+        using var menu = CreateInstanceMenu();
+
+        using var submenu = InstanceManager.CreateInstanceSubmenu(menu, "Home");
+        using var repeatedSubmenu = InstanceManager.CreateInstanceSubmenu(menu, "Home");
+
+        menu.Items[0].Name.Should().Be("Home");
+        menu.Items[1].Name.Should().Be("AddInstanceSeparator");
+        menu.Items.Cast<ToolStripItem>().Count(item => item.Name == "Home").Should().Be(1);
+        menu.Items.Cast<ToolStripItem>().Count(item => item.Name == "AddInstanceSeparator").Should().Be(1);
+        repeatedSubmenu.Text.Should().Be("Home");
+    }
+
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 1)]
+    [InlineData(true, 2)]
+    [InlineData(false, 2)]
+    public void ShowHideInstances_UpdatesEveryWindowAndMenu(bool initiallyVisible, int instanceCount)
+    {
+        using var firstForm = new VisibilityTestForm();
+        using var secondForm = new VisibilityTestForm();
+        using var firstMenu = CreateInstanceMenu();
+        using var secondMenu = CreateInstanceMenu();
+        using var globalMenu = CreateInstanceMenu();
+        var menu = instanceCount == 1 ? firstMenu : globalMenu;
+        menu.Items["HideShowMenu"]!.Text = initiallyVisible
+            ? instanceCount == 1 ? Resources.Hide : Resources.HideAll
+            : instanceCount == 1 ? Resources.Show : Resources.ShowAll;
+        var instances = new List<(Form Form, ContextMenuStrip Menu)> { (firstForm, firstMenu) };
+        if (instanceCount == 2)
+        {
+            instances.Add((secondForm, secondMenu));
+        }
+
+        InstanceManager.ShowHideInstances(menu, instances);
+
+        firstForm.RequestedVisibility.Should().Be(!initiallyVisible);
+        firstMenu.Items["HideShowMenu"]!.Text.Should().Be(initiallyVisible ? Resources.Show : Resources.Hide);
+        if (instanceCount == 2)
+        {
+            secondForm.RequestedVisibility.Should().Be(!initiallyVisible);
+            secondMenu.Items["HideShowMenu"]!.Text.Should().Be(initiallyVisible ? Resources.Show : Resources.Hide);
+            menu.Items["HideShowMenu"]!.Text.Should().Be(initiallyVisible ? Resources.ShowAll : Resources.HideAll);
+        }
+    }
+
+    [Fact]
+    public void ShowHideInstances_UnknownLabelDoesNothing()
+    {
+        using var form = new VisibilityTestForm();
+        using var menu = CreateInstanceMenu();
+        menu.Items["HideShowMenu"]!.Text = "Unknown";
+
+        InstanceManager.ShowHideInstances(menu, new[] { ((Form)form, menu) });
+
+        form.RequestedVisibility.Should().BeNull();
+        menu.Items["HideShowMenu"]!.Text.Should().Be("Unknown");
+    }
+
+    private sealed class VisibilityTestForm : Form
+    {
+        public bool? RequestedVisibility { get; private set; }
+
+        protected override void SetVisibleCore(bool value)
+        {
+            RequestedVisibility = value;
+        }
+    }
+
+    private static ContextMenuStrip CreateInstanceMenu()
+    {
+        var menu = new ContextMenuStrip();
+        foreach (var name in new[] { "CalendarMenu", "InboxMenu", "ContactsMenu", "TasksMenu", "NotesMenu",
+                     "Separator1", "DateMenu", "Separator2", "PreferencesMenu", "Separator3", "HideShowMenu",
+                     "DisableEnableEditingMenu", "Separator4", "OpacityMenu", "Separator5", "RemoveInstanceMenu",
+                     "RenameInstanceMenu", "Separator6", "ExitMenu" })
+        {
+            menu.Items.Add(new ToolStripMenuItem(name) { Name = name });
+        }
+
+        return menu;
     }
 
     [Fact]

--- a/OotD.Core.Tests/Utility/StickyWindowSnapTests.cs
+++ b/OotD.Core.Tests/Utility/StickyWindowSnapTests.cs
@@ -37,6 +37,60 @@ public class StickyWindowSnapTests
 
     #region ComputeMoveSnap
 
+    [Theory]
+    [InlineData(UnsafeNativeMethods.HT.HTTOPLEFT, 10)]
+    [InlineData(UnsafeNativeMethods.HT.HTTOP, 2)]
+    [InlineData(UnsafeNativeMethods.HT.HTTOPRIGHT, 18)]
+    [InlineData(UnsafeNativeMethods.HT.HTRIGHT, 16)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOMRIGHT, 20)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOM, 4)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOMLEFT, 12)]
+    [InlineData(UnsafeNativeMethods.HT.HTLEFT, 8)]
+    [InlineData(UnsafeNativeMethods.HT.HTCAPTION, 0)]
+    [InlineData(-1, 0)]
+    public void GetResizeDirection_MapsOnlyResizeTargets(int hitTest, int expected)
+    {
+        StickyWindow.GetResizeDirection(hitTest).Should().Be((StickyWindow.ResizeDir)expected);
+    }
+
+    [Theory]
+    [InlineData(-2100, -100, -1925, -7)]
+    [InlineData(100, 1200, -5, 1073)]
+    [InlineData(-1000, 500, -1005, 493)]
+    public void ComputeMoveBounds_ClampsCursorBeforeSubtractingDragOffset(int mouseX, int mouseY,
+        int expectedX, int expectedY)
+    {
+        var result = StickyWindow.ComputeMoveBounds(new Rectangle(0, 0, 300, 200), new Point(mouseX, mouseY),
+            new Point(5, 7), new Rectangle(-1920, 0, 1920, 1080), [], Gap, false, false);
+
+        result.Should().Be(new Rectangle(expectedX, expectedY, 300, 200));
+    }
+
+    [Theory]
+    [InlineData(false, false, 7)]
+    [InlineData(true, false, 0)]
+    [InlineData(false, true, 5)]
+    [InlineData(true, true, 5)]
+    public void ComputeMoveBounds_HonorsSnapOptionsAndClosestTarget(bool stickToScreen, bool stickToOther,
+        int expectedX)
+    {
+        var otherWindows = new[] { new Rectangle(-295, 450, 300, 400), new Rectangle(-299, 450, 300, 400) };
+
+        var result = StickyWindow.ComputeMoveBounds(new Rectangle(0, 0, 300, 200), new Point(7, 500),
+            Point.Empty, Screen, otherWindows, Gap, stickToScreen, stickToOther);
+
+        result.Should().Be(new Rectangle(expectedX, 500, 300, 200));
+    }
+
+    [Fact]
+    public void ComputeMoveBounds_NoNearbyTargetsPreservesUnsnappedPosition()
+    {
+        var result = StickyWindow.ComputeMoveBounds(new Rectangle(0, 0, 300, 200), new Point(500, 500),
+            Point.Empty, Screen, [], Gap, true, true);
+
+        result.Should().Be(new Rectangle(500, 500, 300, 200));
+    }
+
     [Fact]
     public void ComputeMoveSnap_WhenLeftEdgeWithinGapOfScreenLeft_SnapsLeftToLeft()
     {
@@ -99,6 +153,113 @@ public class StickyWindowSnapTests
     #endregion
 
     #region ComputeResizeSnap
+
+    [Theory]
+    [InlineData(false, false, 0, 0)]
+    [InlineData(true, false, 5, 6)]
+    [InlineData(false, true, 4, 0)]
+    [InlineData(true, true, 4, 6)]
+    public void ComputeResizeOffsets_PreservesSnapOptionsAndTargetOrder(bool stickToScreen, bool stickToOther,
+        int expectedWidthOffset, int expectedHeightOffset)
+    {
+        var otherWindows = new[] { new Rectangle(1918, 1000, 300, 100), new Rectangle(1919, 1000, 300, 100) };
+
+        var result = StickyWindow.ComputeResizeOffsets(new Rectangle(1000, 800, 915, 274), Screen, otherWindows,
+            StickyWindow.ResizeDir.Right | StickyWindow.ResizeDir.Bottom, Gap, stickToScreen, stickToOther);
+
+        result.Should().Be(new Rectangle(11, 11, expectedWidthOffset, expectedHeightOffset));
+    }
+
+    [Fact]
+    public void ComputeResizeOffsets_NoNearbyTargetsPreservesSeed()
+    {
+        var result = StickyWindow.ComputeResizeOffsets(new Rectangle(500, 500, 300, 200), Screen, [],
+            StickyWindow.ResizeDir.Top | StickyWindow.ResizeDir.Left, Gap, true, true);
+
+        result.Should().Be(ResizeSeed);
+    }
+
+    [Theory]
+    [InlineData(8, 80, 100, 320, 200)]
+    [InlineData(16, 100, 100, -20, 200)]
+    [InlineData(2, 100, 70, 300, 230)]
+    [InlineData(4, 100, 100, 300, -30)]
+    [InlineData(10, 80, 70, 320, 230)]
+    [InlineData(18, 100, 70, -20, 230)]
+    [InlineData(12, 80, 100, 320, -30)]
+    [InlineData(20, 100, 100, -20, -30)]
+    [InlineData(0, 100, 100, 300, 200)]
+    public void StretchResizeBounds_ChangesOnlyDraggedEdges(int direction, int left, int top, int width, int height)
+    {
+        var result = StickyWindow.StretchResizeBounds(new Rectangle(100, 100, 300, 200), new Point(80, 70),
+            (StickyWindow.ResizeDir)direction);
+
+        result.Should().Be(new Rectangle(left, top, width, height));
+    }
+
+    [Theory]
+    [InlineData(50, 100, 0, 80, 1000, 100)]
+    [InlineData(50, 60, 0, 80, 1000, 80)]
+    [InlineData(1200, 100, 0, 80, 1000, 1000)]
+    [InlineData(1200, 100, 500, 80, 1000, 500)]
+    [InlineData(300, 100, 500, 80, 1000, 300)]
+    [InlineData(300, 100, 50, 80, 1000, 100)]
+    public void ConstrainResizeDimension_RespectsLimitPrecedence(int value, int minimum, int maximum,
+        int minimumTrack, int maximumTrack, int expected)
+    {
+        StickyWindow.ConstrainResizeDimension(value, minimum, maximum, minimumTrack, maximumTrack)
+            .Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(11, 0)]
+    [InlineData(10, 10)]
+    [InlineData(-10, -10)]
+    [InlineData(0, 0)]
+    public void ClearSnapSentinel_OnlyClearsUnchangedOffsets(int offset, int expected)
+    {
+        StickyWindow.ClearSnapSentinel(offset, Gap).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ApplyResizeOffsets_TopLeftLimitsKeepOppositeCornerFixed()
+    {
+        var original = new Rectangle(100, 100, 300, 200);
+        var stretched = StickyWindow.StretchResizeBounds(original, new Point(390, 290),
+            StickyWindow.ResizeDir.Top | StickyWindow.ResizeDir.Left);
+
+        var result = StickyWindow.ApplyResizeOffsets(original, stretched, ResizeSeed,
+            StickyWindow.ResizeDir.Top | StickyWindow.ResizeDir.Left, Gap,
+            new Size(100, 80), Size.Empty, new Size(40, 30), new Size(1000, 1000));
+
+        result.Should().Be(new Rectangle(300, 220, 100, 80));
+    }
+
+    [Theory]
+    [InlineData(10, 96, 96, 304, 204)]
+    [InlineData(20, 100, 100, 304, 204)]
+    public void ApplyResizeOffsets_CombinesOffsetsAndPreservesAnchors(int direction, int left, int top,
+        int width, int height)
+    {
+        var bounds = new Rectangle(100, 100, 300, 200);
+
+        var result = StickyWindow.ApplyResizeOffsets(bounds, bounds, new Rectangle(7, -2, -3, 6),
+            (StickyWindow.ResizeDir)direction, Gap, Size.Empty, Size.Empty, Size.Empty, new Size(1000, 1000));
+
+        result.Should().Be(new Rectangle(left, top, width, height));
+    }
+
+    [Fact]
+    public void ApplyResizeOffsets_ClearsSentinelsInEveryComponent()
+    {
+        var bounds = new Rectangle(100, 100, 300, 200);
+
+        var result = StickyWindow.ApplyResizeOffsets(bounds, bounds, new Rectangle(11, 11, 11, 11),
+            StickyWindow.ResizeDir.Bottom | StickyWindow.ResizeDir.Right, Gap,
+            new Size(500, 500), new Size(600, 600), Size.Empty, new Size(1000, 1000));
+
+        result.Should().Be(bounds);
+    }
 
     [Fact]
     public void ComputeResizeSnap_WhenRightEdgeWithinGapOfScreenRight_SnapsRightToRight()

--- a/OotD.Core.Tests/Utility/StickyWindowTests.cs
+++ b/OotD.Core.Tests/Utility/StickyWindowTests.cs
@@ -263,6 +263,49 @@ public class StickyWindowTests : IDisposable
         _stickyWindow.StickToOther.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData(UnsafeNativeMethods.HT.HTTOPLEFT)]
+    [InlineData(UnsafeNativeMethods.HT.HTTOP)]
+    [InlineData(UnsafeNativeMethods.HT.HTTOPRIGHT)]
+    [InlineData(UnsafeNativeMethods.HT.HTRIGHT)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOMRIGHT)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOM)]
+    [InlineData(UnsafeNativeMethods.HT.HTBOTTOMLEFT)]
+    [InlineData(UnsafeNativeMethods.HT.HTLEFT)]
+    public void OnNCLButtonDown_ResizeTargetsRespectStickOnResize(int hitTest)
+    {
+        _stickyWindow = new StickyWindow(_testForm!) { StickOnResize = false };
+        var method = typeof(StickyWindow).GetMethod("OnNCLButtonDown",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        method.Invoke(_stickyWindow, [hitTest, Point.Empty]).Should().Be(false);
+        _stickyWindow.StickOnResize = true;
+        method.Invoke(_stickyWindow, [hitTest, Point.Empty]).Should().Be(true);
+        method.Invoke(_stickyWindow, [hitTest, Point.Empty]).Should().Be(true);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OnNCLButtonDown_CaptionRespectsStickOnMove(bool stickOnMove)
+    {
+        _stickyWindow = new StickyWindow(_testForm!) { StickOnMove = stickOnMove };
+        var method = typeof(StickyWindow).GetMethod("OnNCLButtonDown",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        method.Invoke(_stickyWindow, [UnsafeNativeMethods.HT.HTCAPTION, Point.Empty]).Should().Be(stickOnMove);
+    }
+
+    [Fact]
+    public void OnNCLButtonDown_UnknownTargetIsNotHandled()
+    {
+        _stickyWindow = new StickyWindow(_testForm!);
+        var method = typeof(StickyWindow).GetMethod("OnNCLButtonDown",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        method.Invoke(_stickyWindow, [-1, Point.Empty]).Should().Be(false);
+    }
+
     public void Dispose()
     {
         _stickyWindow?.ReleaseHandle();

--- a/OotD.Core/Forms/InstanceManager.cs
+++ b/OotD.Core/Forms/InstanceManager.cs
@@ -108,244 +108,43 @@ public partial class InstanceManager : Form
     {
         _logger.Debug("Loading app settings from registry");
 
-        // Each subkey in our main registry key represents an instance. 
-        // Read each subkey and load the instance.
-        using (var appReg = Registry.CurrentUser.CreateSubKey(PreferencesRegistry.RootPath))
+        using var appReg = Registry.CurrentUser.CreateSubKey(PreferencesRegistry.RootPath);
+        var instanceNames = FilterInstanceNames(appReg.GetSubKeyNames()).ToArray();
+
+        if (instanceNames.Length > 1)
         {
-            _logger.Debug("Settings Found.");
-
-            if (InstanceCount > 1)
+            var menu = CreateMultipleInstanceMenu();
+            trayIcon.ContextMenuStrip = menu;
+            var insertionIndex = 2;
+            foreach (var instanceName in instanceNames)
             {
-                _logger.Debug("Multiple instances to load");
+                var instance = GetOrCreateInstance(instanceName, out var newlyAdded);
+                instance.InstanceRemoved -= InstanceRemovedEventHandler;
+                instance.InstanceRemoved += InstanceRemovedEventHandler;
+                instance.InstanceRenamed -= InstanceRenamedEventHandler;
+                instance.InstanceRenamed += InstanceRenamedEventHandler;
 
-                // There are multiple instances defined, so we build the context menu strip dynamically.
-                trayIcon.ContextMenuStrip = new ContextMenuStrip();
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.AddInstance, null,
-                    AddInstanceMenu_Click, "AddInstanceMenu"));
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-
-                var instanceSubmenu = new ToolStripMenuItem[InstanceCount];
-                var count = 0;
-
-                // each instance will get it's own submenu in the main context menu.
-                foreach (var instanceName in FilterInstanceNames(appReg.GetSubKeyNames()))
-                {
-                    var newlyAdded = false;
-                    if (!_mainFormInstances.TryGetValue(instanceName, out var value))
-                    {
-                        _logger.Debug($"Instantiating instance {instanceName}");
-                        value = new MainForm(instanceName);
-                        _mainFormInstances.Add(instanceName, value);
-                        newlyAdded = true;
-                    }
-
-                    value.InstanceRemoved += InstanceRemovedEventHandler;
-                    value.InstanceRenamed += InstanceRenamedEventHandler;
-
-                    // create the submenu for the instance
-                    instanceSubmenu[count] = new ToolStripMenuItem(instanceName, null, null, instanceName);
-                    trayIcon.ContextMenuStrip.Items.Add(instanceSubmenu[count]);
-
-                    // add the name of the instance to the top of the submenu so it's clear which
-                    // instance the submenu belongs to.
-                    if (!value.TrayMenu.Items.ContainsKey(instanceName))
-                    {
-                        value.TrayMenu.Items.Insert(0,
-                            new ToolStripMenuItem(instanceName) { Name = instanceName });
-                        value.TrayMenu.Items[0].BackColor = Color.Gainsboro;
-
-                        if (!value.TrayMenu.Items.ContainsKey("AddInstanceSeparator"))
-                        {
-                            value.TrayMenu.Items.Insert(1,
-                                new ToolStripSeparator { Name = "AddInstanceSeparator" });
-                        }
-                    }
-
-                    // the submenu items are set to the context menu defined in the form's instance.
-                    instanceSubmenu[count].DropDown = value.TrayMenu;
-                    instanceSubmenu[count].DropDownOpened += InstanceContextMenu_DropDownOpened;
-                    value.TrayMenu.Items["RemoveInstanceMenu"]!.Visible = true;
-                    value.TrayMenu.Items["RenameInstanceMenu"]!.Visible = true;
-
-                    if (value.TrayMenu.Items.ContainsKey("AddInstanceMenu"))
-                    {
-                        value.TrayMenu.Items["AddInstanceMenu"]!.Visible = false;
-                    }
-
-                    if (value.TrayMenu.Items.ContainsKey("AboutMenu"))
-                    {
-                        value.TrayMenu.Items["AboutMenu"]!.Visible = false;
-                    }
-
-                    if (value.TrayMenu.Items.ContainsKey("StartWithWindows"))
-                    {
-                        value.TrayMenu.Items["StartWithWindows"]!.Visible = false;
-                    }
-
-                    if (value.TrayMenu.Items.ContainsKey("LockPositionMenu"))
-                    {
-                        value.TrayMenu.Items["LockPositionMenu"]!.Visible = false;
-                    }
-
-                    if (value.TrayMenu.Items.ContainsKey("CheckForUpdatesMenu"))
-                    {
-                        value.TrayMenu.Items["CheckForUpdatesMenu"]!.Visible = false;
-                    }
-
-                    value.TrayMenu.Items["Separator6"]!.Visible = false;
-                    value.TrayMenu.Items["ExitMenu"]!.Visible = false;
-
-                    // finally, show the form
-                    if (newlyAdded)
-                    {
-                        _logger.Debug($"Showing Instance {instanceName}");
-                        value.Show();
-                        UnsafeNativeMethods.SendWindowToBack(value);
-                    }
-
-                    count++;
-                }
-
-                // add the rest of the necessary menu items to the main context menu.
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.StartWithWindows, null,
-                    StartWithWindowsMenu_Click, "StartWithWindows"));
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.HideAll, null,
-                    HideShowAllMenu_Click, "HideShowMenu"));
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.LockPosition, null,
-                    LockPositionMenu_Click, "LockPositionMenu"));
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.DisableEditing, null,
-                    DisableEnableEditingMenu_Click, "DisableEnableEditingMenu"));
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.About, null, AboutMenu_Click,
-                    "AboutMenu"));
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.CheckForUpdates, null,
-                    CheckForUpdates_Click, "CheckForUpdatesMenu"));
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.RestoreDefaults, null,
-                    ResetConfigMenu_Click, ResetConfigMenuName));
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-
-                trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.Exit, null, ExitMenu_Click,
-                    "ExitMenu"));
+                var submenu = CreateInstanceSubmenu(instance.TrayMenu, instanceName);
+                submenu.DropDownOpened += InstanceContextMenu_DropDownOpened;
+                menu.Items.Insert(insertionIndex++, submenu);
+                ShowNewInstance(instance, newlyAdded);
             }
-            else
+        }
+        else
+        {
+            var instanceName = ResolveSingleInstanceName(instanceNames.Length, instanceNames, "Default Instance");
+            var instance = GetOrCreateInstance(instanceName, out var newlyAdded);
+            trayIcon.ContextMenuStrip = instance.TrayMenu;
+            ConfigureSingleInstanceMenu(instance.TrayMenu, new Dictionary<string, EventHandler>
             {
-                // this is a first run, or there is only 1 instance defined.
-                const string DefaultInstanceName = "Default Instance";
-
-                var instanceName = ResolveSingleInstanceName(InstanceCount, appReg.GetSubKeyNames(),
-                    DefaultInstanceName);
-
-                // create our instance and set the context menu to one defined in the form instance.
-                var newlyAdded = false;
-                if (!_mainFormInstances.TryGetValue(instanceName, out var value))
-                {
-                    value = new MainForm(instanceName);
-                    _mainFormInstances.Add(instanceName, value);
-                    newlyAdded = true;
-                }
-
-                trayIcon.ContextMenuStrip = value.TrayMenu;
-
-                // remove unnecessary menu items
-                TrimSingleInstanceMenuItems(trayIcon.ContextMenuStrip);
-
-                trayIcon.ContextMenuStrip.Items["RemoveInstanceMenu"]!.Visible = false;
-                trayIcon.ContextMenuStrip.Items["RenameInstanceMenu"]!.Visible = false;
-
-                if (value.TrayMenu.Items.ContainsKey("AddInstanceMenu"))
-                {
-                    value.TrayMenu.Items["AddInstanceMenu"]!.Visible = true;
-                }
-
-                if (value.TrayMenu.Items.ContainsKey("AboutMenu"))
-                {
-                    value.TrayMenu.Items["AboutMenu"]!.Visible = true;
-                }
-
-                if (value.TrayMenu.Items.ContainsKey("StartWithWindows"))
-                {
-                    value.TrayMenu.Items["StartWithWindows"]!.Visible = true;
-                }
-
-                if (value.TrayMenu.Items.ContainsKey("LockPositionMenu"))
-                {
-                    value.TrayMenu.Items["LockPositionMenu"]!.Visible = true;
-                }
-
-                if (value.TrayMenu.Items.ContainsKey("CheckForUpdatesMenu"))
-                {
-                    value.TrayMenu.Items["CheckForUpdatesMenu"]!.Visible = true;
-                }
-
-                // add global menu items that don't apply to the instance.
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey("AddInstanceMenu"))
-                {
-                    trayIcon.ContextMenuStrip.Items.Insert(0,
-                        new ToolStripMenuItem(Resources.AddInstance, null, AddInstanceMenu_Click, "AddInstanceMenu"));
-
-                    trayIcon.ContextMenuStrip.Items.Insert(1, new ToolStripSeparator { Name = "AddInstanceSeparator" });
-                }
-
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey("StartWithWindows"))
-                {
-                    trayIcon.ContextMenuStrip.Items.Insert(12,
-                        new ToolStripMenuItem(Resources.StartWithWindows, null, StartWithWindowsMenu_Click,
-                            "StartWithWindows"));
-                }
-
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey("LockPositionMenu"))
-                {
-                    trayIcon.ContextMenuStrip.Items.Insert(15,
-                        new ToolStripMenuItem(Resources.LockPosition, null, LockPositionMenu_Click,
-                            "LockPositionMenu"));
-                }
-
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey("CheckForUpdatesMenu"))
-                {
-                    trayIcon.ContextMenuStrip.Items.Insert(20,
-                        new ToolStripMenuItem(Resources.CheckForUpdates, null, CheckForUpdates_Click,
-                            "CheckForUpdatesMenu"));
-                }
-
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey("AboutMenu"))
-                {
-                    trayIcon.ContextMenuStrip.Items.Insert(20,
-                        new ToolStripMenuItem(Resources.About, null, AboutMenu_Click, "AboutMenu"));
-                }
-
-                if (!trayIcon.ContextMenuStrip.Items.ContainsKey(ResetConfigMenuName))
-                {
-                    var exitMenuIndex = trayIcon.ContextMenuStrip.Items.IndexOfKey("ExitMenu");
-                    if (exitMenuIndex >= 0)
-                    {
-                        trayIcon.ContextMenuStrip.Items.Insert(exitMenuIndex,
-                            new ToolStripMenuItem(Resources.RestoreDefaults, null, ResetConfigMenu_Click,
-                                ResetConfigMenuName));
-                    }
-                    else
-                    {
-                        trayIcon.ContextMenuStrip.Items.Add(new ToolStripMenuItem(Resources.RestoreDefaults, null,
-                            ResetConfigMenu_Click, ResetConfigMenuName));
-                    }
-                }
-
-                value.TrayMenu.Items["Separator6"]!.Visible = true;
-                value.TrayMenu.Items["ExitMenu"]!.Visible = true;
-
-                if (newlyAdded)
-                {
-                    value.Show();
-                    UnsafeNativeMethods.SendWindowToBack(value);
-                }
-            }
+                ["AddInstanceMenu"] = AddInstanceMenu_Click,
+                ["StartWithWindows"] = StartWithWindowsMenu_Click,
+                ["LockPositionMenu"] = LockPositionMenu_Click,
+                [CheckForUpdatesMenuName] = CheckForUpdates_Click,
+                [AboutMenuName] = AboutMenu_Click,
+                [ResetConfigMenuName] = ResetConfigMenu_Click
+            });
+            ShowNewInstance(instance, newlyAdded);
         }
 
         ReorderBottomMenuItems();
@@ -356,6 +155,121 @@ public partial class InstanceManager : Form
         var lockPositionMenu = trayIcon.ContextMenuStrip.Items["LockPositionMenu"] as ToolStripMenuItem;
         lockPositionMenu!.Checked = GlobalPreferences.LockPosition;
         LockOrUnlock(GlobalPreferences.LockPosition);
+    }
+
+    private MainForm GetOrCreateInstance(string instanceName, out bool newlyAdded)
+    {
+        newlyAdded = !_mainFormInstances.TryGetValue(instanceName, out var instance);
+        if (newlyAdded)
+        {
+            _logger.Debug($"Instantiating instance {instanceName}");
+            instance = new MainForm(instanceName);
+            _mainFormInstances.Add(instanceName, instance);
+        }
+
+        return instance!;
+    }
+
+    private static void ShowNewInstance(MainForm instance, bool newlyAdded)
+    {
+        if (!newlyAdded)
+        {
+            return;
+        }
+
+        instance.Show();
+        UnsafeNativeMethods.SendWindowToBack(instance);
+    }
+
+    private ContextMenuStrip CreateMultipleInstanceMenu()
+    {
+        var menu = new ContextMenuStrip();
+        menu.Items.Add(new ToolStripMenuItem(Resources.AddInstance, null, AddInstanceMenu_Click, "AddInstanceMenu"));
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripMenuItem(Resources.StartWithWindows, null, StartWithWindowsMenu_Click,
+            "StartWithWindows"));
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripMenuItem(Resources.HideAll, null, HideShowAllMenu_Click, "HideShowMenu"));
+        menu.Items.Add(new ToolStripMenuItem(Resources.LockPosition, null, LockPositionMenu_Click, "LockPositionMenu"));
+        menu.Items.Add(new ToolStripMenuItem(Resources.DisableEditing, null, DisableEnableEditingMenu_Click,
+            "DisableEnableEditingMenu"));
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripMenuItem(Resources.About, null, AboutMenu_Click, AboutMenuName));
+        menu.Items.Add(new ToolStripMenuItem(Resources.CheckForUpdates, null, CheckForUpdates_Click,
+            CheckForUpdatesMenuName));
+        menu.Items.Add(new ToolStripMenuItem(Resources.RestoreDefaults, null, ResetConfigMenu_Click, ResetConfigMenuName));
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(new ToolStripMenuItem(Resources.Exit, null, ExitMenu_Click, "ExitMenu"));
+        return menu;
+    }
+
+    internal static ToolStripMenuItem CreateInstanceSubmenu(ContextMenuStrip menu, string instanceName)
+    {
+        if (!menu.Items.ContainsKey(instanceName))
+        {
+            menu.Items.Insert(0, new ToolStripMenuItem(instanceName)
+            {
+                Name = instanceName,
+                BackColor = Color.Gainsboro
+            });
+
+            if (!menu.Items.ContainsKey("AddInstanceSeparator"))
+            {
+                menu.Items.Insert(1, new ToolStripSeparator { Name = "AddInstanceSeparator" });
+            }
+        }
+
+        SetInstanceMenuVisibility(menu, true);
+        return new ToolStripMenuItem(instanceName, null, null, instanceName) { DropDown = menu };
+    }
+
+    internal static void SetInstanceMenuVisibility(ContextMenuStrip menu, bool multipleInstances)
+    {
+        menu.Items["RemoveInstanceMenu"]!.Visible = multipleInstances;
+        menu.Items["RenameInstanceMenu"]!.Visible = multipleInstances;
+        menu.Items["Separator6"]!.Visible = !multipleInstances;
+        menu.Items["ExitMenu"]!.Visible = !multipleInstances;
+
+        foreach (var name in new[] { "AddInstanceMenu", AboutMenuName, "StartWithWindows", "LockPositionMenu",
+                     CheckForUpdatesMenuName })
+        {
+            if (menu.Items[name] is { } item)
+            {
+                item.Visible = !multipleInstances;
+            }
+        }
+    }
+
+    internal static void ConfigureSingleInstanceMenu(ContextMenuStrip menu,
+        IReadOnlyDictionary<string, EventHandler> handlers)
+    {
+        TrimSingleInstanceMenuItems(menu);
+        SetInstanceMenuVisibility(menu, false);
+        if (EnsureMenuItem(menu, 0, Resources.AddInstance, "AddInstanceMenu", handlers))
+        {
+            menu.Items.Insert(1, new ToolStripSeparator { Name = "AddInstanceSeparator" });
+        }
+
+        EnsureMenuItem(menu, 12, Resources.StartWithWindows, "StartWithWindows", handlers);
+        EnsureMenuItem(menu, 15, Resources.LockPosition, "LockPositionMenu", handlers);
+        EnsureMenuItem(menu, 20, Resources.CheckForUpdates, CheckForUpdatesMenuName, handlers);
+        EnsureMenuItem(menu, 20, Resources.About, AboutMenuName, handlers);
+        var exitIndex = menu.Items.IndexOfKey("ExitMenu");
+        EnsureMenuItem(menu, exitIndex < 0 ? menu.Items.Count : exitIndex, Resources.RestoreDefaults,
+            ResetConfigMenuName, handlers);
+    }
+
+    private static bool EnsureMenuItem(ContextMenuStrip menu, int index, string text, string name,
+        IReadOnlyDictionary<string, EventHandler> handlers)
+    {
+        if (menu.Items.ContainsKey(name))
+        {
+            return false;
+        }
+
+        menu.Items.Insert(index, new ToolStripMenuItem(text, null, handlers[name], name));
+        return true;
     }
 
     private void ReorderBottomMenuItems()
@@ -676,30 +590,43 @@ public partial class InstanceManager : Form
 
     private void ShowHideAllInstances()
     {
-        var hideShowMenuText = trayIcon.ContextMenuStrip!.Items["HideShowMenu"]!.Text;
+        ShowHideInstances(trayIcon.ContextMenuStrip!,
+            _mainFormInstances.Values.Select(instance => ((Form)instance, instance.TrayMenu)).ToArray());
+    }
 
-        if (hideShowMenuText == Resources.HideAll || hideShowMenuText == Resources.Hide)
+    internal static void ShowHideInstances(ContextMenuStrip menu,
+        IReadOnlyCollection<(Form Form, ContextMenuStrip Menu)> instances)
+    {
+        var visible = ResolveVisibility(menu.Items["HideShowMenu"]!.Text);
+        if (visible == null)
         {
-            foreach (var (_, mainForm) in _mainFormInstances)
-            {
-                mainForm.Visible = false;
-                mainForm.TrayMenu.Items["HideShowMenu"]!.Text = Resources.Show;
-            }
-
-            trayIcon.ContextMenuStrip.Items["HideShowMenu"]!.Text =
-                _mainFormInstances.Count == 1 ? Resources.Show : Resources.ShowAll;
+            return;
         }
-        else if (hideShowMenuText == Resources.ShowAll || hideShowMenuText == Resources.Show)
+
+        foreach (var (form, instanceMenu) in instances)
         {
-            foreach (var (_, mainForm) in _mainFormInstances)
-            {
-                mainForm.Visible = true;
-                mainForm.TrayMenu.Items["HideShowMenu"]!.Text = Resources.Hide;
-            }
-
-            trayIcon.ContextMenuStrip.Items["HideShowMenu"]!.Text =
-                _mainFormInstances.Count == 1 ? Resources.Hide : Resources.HideAll;
+            form.Visible = visible.Value;
+            instanceMenu.Items["HideShowMenu"]!.Text = GetVisibilityMenuText(visible.Value, 1);
         }
+
+        menu.Items["HideShowMenu"]!.Text = GetVisibilityMenuText(visible.Value, instances.Count);
+    }
+
+    private static bool? ResolveVisibility(string? menuText)
+    {
+        if (menuText == Resources.HideAll || menuText == Resources.Hide)
+        {
+            return false;
+        }
+
+        return menuText == Resources.ShowAll || menuText == Resources.Show ? true : null;
+    }
+
+    private static string GetVisibilityMenuText(bool visible, int instanceCount)
+    {
+        return visible
+            ? instanceCount == 1 ? Resources.Hide : Resources.HideAll
+            : instanceCount == 1 ? Resources.Show : Resources.ShowAll;
     }
 
     private void LockPositionMenu_Click(object? sender, EventArgs e)

--- a/OotD.Core/Utility/StickyWindow.cs
+++ b/OotD.Core/Utility/StickyWindow.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace OotD.Utility;
@@ -35,9 +37,7 @@ public sealed class StickyWindow : NativeWindow
         _originalForm = form;
 
         _formRect = Rectangle.Empty;
-        _formOffsetRect = Rectangle.Empty;
 
-        _formOffsetPoint = Point.Empty;
         _offsetPoint = Point.Empty;
         _mousePoint = Point.Empty;
 
@@ -134,42 +134,37 @@ public sealed class StickyWindow : NativeWindow
     {
         _offsetPoint = point;
 
-        switch (iHitTest)
+        if (iHitTest == UnsafeNativeMethods.HT.HTCAPTION)
         {
-            case UnsafeNativeMethods.HT.HTCAPTION:
-                {
-                    // request for move
-                    if (!StickOnMove)
-                    {
-                        return false; // leave default processing
-                    }
+            if (!StickOnMove)
+            {
+                return false;
+            }
 
-                    var pointInApp = _originalForm.PointToClient(Cursor.Position);
-                    _offsetPoint.Offset(pointInApp.X, pointInApp.Y);
-                    StartMove();
-                    return true;
-                }
-
-            // requests for resize
-            case UnsafeNativeMethods.HT.HTTOPLEFT:
-                return StartResize(ResizeDir.Top | ResizeDir.Left);
-            case UnsafeNativeMethods.HT.HTTOP:
-                return StartResize(ResizeDir.Top);
-            case UnsafeNativeMethods.HT.HTTOPRIGHT:
-                return StartResize(ResizeDir.Top | ResizeDir.Right);
-            case UnsafeNativeMethods.HT.HTRIGHT:
-                return StartResize(ResizeDir.Right);
-            case UnsafeNativeMethods.HT.HTBOTTOMRIGHT:
-                return StartResize(ResizeDir.Bottom | ResizeDir.Right);
-            case UnsafeNativeMethods.HT.HTBOTTOM:
-                return StartResize(ResizeDir.Bottom);
-            case UnsafeNativeMethods.HT.HTBOTTOMLEFT:
-                return StartResize(ResizeDir.Bottom | ResizeDir.Left);
-            case UnsafeNativeMethods.HT.HTLEFT:
-                return StartResize(ResizeDir.Left);
+            var pointInApp = _originalForm.PointToClient(Cursor.Position);
+            _offsetPoint.Offset(pointInApp.X, pointInApp.Y);
+            StartMove();
+            return true;
         }
 
-        return false;
+        var direction = GetResizeDirection(iHitTest);
+        return direction != 0 && StartResize(direction);
+    }
+
+    internal static ResizeDir GetResizeDirection(int hitTest)
+    {
+        return hitTest switch
+        {
+            UnsafeNativeMethods.HT.HTTOPLEFT => ResizeDir.Top | ResizeDir.Left,
+            UnsafeNativeMethods.HT.HTTOP => ResizeDir.Top,
+            UnsafeNativeMethods.HT.HTTOPRIGHT => ResizeDir.Top | ResizeDir.Right,
+            UnsafeNativeMethods.HT.HTRIGHT => ResizeDir.Right,
+            UnsafeNativeMethods.HT.HTBOTTOMRIGHT => ResizeDir.Bottom | ResizeDir.Right,
+            UnsafeNativeMethods.HT.HTBOTTOM => ResizeDir.Bottom,
+            UnsafeNativeMethods.HT.HTBOTTOMLEFT => ResizeDir.Bottom | ResizeDir.Left,
+            UnsafeNativeMethods.HT.HTLEFT => ResizeDir.Left,
+            _ => 0
+        };
     }
 
     #endregion
@@ -244,13 +239,11 @@ public sealed class StickyWindow : NativeWindow
 
     // Move stuff
     private bool _movingForm;
-    private Point _formOffsetPoint; // calculated offset rect to be added !! (min distances in all directions!!)
     private Point _offsetPoint; // primary offset
 
     // Resize stuff
     private bool _resizingForm;
     private ResizeDir _resizeDirection;
-    private Rectangle _formOffsetRect; // calculated rect to fix the size
     private Point _mousePoint; // mouse position
 
     // General Stuff
@@ -391,142 +384,99 @@ public sealed class StickyWindow : NativeWindow
     {
         p = _originalForm.PointToScreen(p);
         var activeScr = Screen.FromPoint(p);
-        _formRect = _originalForm.Bounds;
+        var originalBounds = _originalForm.Bounds;
+        _formRect = StretchResizeBounds(originalBounds, p, _resizeDirection);
 
-        var iRight = _formRect.Right;
-        var iBottom = _formRect.Bottom;
-
-        // no normalize required
-        // first stretch the window to the new position
-        if ((_resizeDirection & ResizeDir.Left) == ResizeDir.Left)
-        {
-            _formRect.Width = _formRect.X - p.X + _formRect.Width;
-            _formRect.X = iRight - _formRect.Width;
-        }
-
-        if ((_resizeDirection & ResizeDir.Right) == ResizeDir.Right)
-        {
-            _formRect.Width = p.X - _formRect.Left;
-        }
-
-        if ((_resizeDirection & ResizeDir.Top) == ResizeDir.Top)
-        {
-            _formRect.Height = _formRect.Height - p.Y + _formRect.Top;
-            _formRect.Y = iBottom - _formRect.Height;
-        }
-
-        if ((_resizeDirection & ResizeDir.Bottom) == ResizeDir.Bottom)
-        {
-            _formRect.Height = p.Y - _formRect.Top;
-        }
-
-        // this is the real new position
-        // now, try to snap it to different objects (first to screen)
-
-        // CARE !!! We use "Width" and "Height" as Bottom & Right!! (C++ style)
-        //formOffsetRect = new Rectangle ( stickGap + 1, stickGap + 1, 0, 0 );
-        _formOffsetRect.X = StickGap + 1;
-        _formOffsetRect.Y = StickGap + 1;
-        _formOffsetRect.Height = 0;
-        _formOffsetRect.Width = 0;
-
-        if (StickToScreen)
-        {
-            Resize_Stick(activeScr.WorkingArea, false);
-        }
-
-        if (StickToOther)
-        {
-            // now try to stick to other forms
-            foreach (var sw in _globalStickyWindows)
-            {
-                var form = sw as Form;
-                if (form == _originalForm)
-                {
-                    continue;
-                }
-
-                if (form != null)
-                {
-                    Resize_Stick(form.Bounds, true);
-                }
-            }
-        }
-
-        // Fix (clear) the values that were not updated to stick
-        if (_formOffsetRect.X == StickGap + 1)
-        {
-            _formOffsetRect.X = 0;
-        }
-
-        if (_formOffsetRect.Width == StickGap + 1)
-        {
-            _formOffsetRect.Width = 0;
-        }
-
-        if (_formOffsetRect.Y == StickGap + 1)
-        {
-            _formOffsetRect.Y = 0;
-        }
-
-        if (_formOffsetRect.Height == StickGap + 1)
-        {
-            _formOffsetRect.Height = 0;
-        }
-
-        // compute the new form size
-        if ((_resizeDirection & ResizeDir.Left) == ResizeDir.Left)
-        {
-            // left resize requires special handling of X & Width according to MinSize and MinWindowTrackSize
-            var iNewWidth = _formRect.Width + _formOffsetRect.Width + _formOffsetRect.X;
-
-            if (_originalForm.MaximumSize.Width != 0)
-            {
-                iNewWidth = Math.Min(iNewWidth, _originalForm.MaximumSize.Width);
-            }
-
-            iNewWidth = Math.Min(iNewWidth, SystemInformation.MaxWindowTrackSize.Width);
-            iNewWidth = Math.Max(iNewWidth, _originalForm.MinimumSize.Width);
-            iNewWidth = Math.Max(iNewWidth, SystemInformation.MinWindowTrackSize.Width);
-
-            _formRect.X = iRight - iNewWidth;
-            _formRect.Width = iNewWidth;
-        }
-        else
-        {
-            // other resizes
-            _formRect.Width += _formOffsetRect.Width + _formOffsetRect.X;
-        }
-
-        if ((_resizeDirection & ResizeDir.Top) == ResizeDir.Top)
-        {
-            var iNewHeight = _formRect.Height + _formOffsetRect.Height + _formOffsetRect.Y;
-
-            if (_originalForm.MaximumSize.Height != 0)
-            {
-                iNewHeight = Math.Min(iNewHeight, _originalForm.MaximumSize.Height);
-            }
-
-            iNewHeight = Math.Min(iNewHeight, SystemInformation.MaxWindowTrackSize.Height);
-            iNewHeight = Math.Max(iNewHeight, _originalForm.MinimumSize.Height);
-            iNewHeight = Math.Max(iNewHeight, SystemInformation.MinWindowTrackSize.Height);
-
-            _formRect.Y = iBottom - iNewHeight;
-            _formRect.Height = iNewHeight;
-        }
-        else
-        {
-            // all other resizing are fine 
-            _formRect.Height += _formOffsetRect.Height + _formOffsetRect.Y;
-        }
-
-        // Done !!
+        var offsets = ComputeResizeOffsets(_formRect, activeScr.WorkingArea, GetOtherWindowBounds(),
+            _resizeDirection, StickGap, StickToScreen, StickToOther);
+        _formRect = ApplyResizeOffsets(originalBounds, _formRect, offsets, _resizeDirection,
+            StickGap, _originalForm.MinimumSize, _originalForm.MaximumSize,
+            SystemInformation.MinWindowTrackSize, SystemInformation.MaxWindowTrackSize);
         _originalForm.Bounds = _formRect;
     }
 
-    private void Resize_Stick(Rectangle toRect, bool bInsideStick)
+    internal static Rectangle StretchResizeBounds(Rectangle bounds, Point mousePoint, ResizeDir direction)
     {
-        _formOffsetRect = ComputeResizeSnap(_formRect, toRect, _formOffsetRect, _resizeDirection, StickGap, bInsideStick);
+        if ((direction & ResizeDir.Left) != 0)
+        {
+            bounds.Width = bounds.Right - mousePoint.X;
+            bounds.X = mousePoint.X;
+        }
+
+        if ((direction & ResizeDir.Right) != 0)
+        {
+            bounds.Width = mousePoint.X - bounds.Left;
+        }
+
+        if ((direction & ResizeDir.Top) != 0)
+        {
+            bounds.Height = bounds.Bottom - mousePoint.Y;
+            bounds.Y = mousePoint.Y;
+        }
+
+        if ((direction & ResizeDir.Bottom) != 0)
+        {
+            bounds.Height = mousePoint.Y - bounds.Top;
+        }
+
+        return bounds;
+    }
+
+    internal static Rectangle ApplyResizeOffsets(Rectangle originalBounds, Rectangle bounds, Rectangle offsets,
+        ResizeDir direction, int stickGap, Size minimumSize, Size maximumSize, Size minimumTrackSize,
+        Size maximumTrackSize)
+    {
+        bounds.Width += ClearSnapSentinel(offsets.X, stickGap) + ClearSnapSentinel(offsets.Width, stickGap);
+        bounds.Height += ClearSnapSentinel(offsets.Y, stickGap) + ClearSnapSentinel(offsets.Height, stickGap);
+
+        if ((direction & ResizeDir.Left) != 0)
+        {
+            bounds.Width = ConstrainResizeDimension(bounds.Width, minimumSize.Width, maximumSize.Width,
+                minimumTrackSize.Width, maximumTrackSize.Width);
+            bounds.X = originalBounds.Right - bounds.Width;
+        }
+
+        if ((direction & ResizeDir.Top) != 0)
+        {
+            bounds.Height = ConstrainResizeDimension(bounds.Height, minimumSize.Height, maximumSize.Height,
+                minimumTrackSize.Height, maximumTrackSize.Height);
+            bounds.Y = originalBounds.Bottom - bounds.Height;
+        }
+
+        return bounds;
+    }
+
+    internal static int ClearSnapSentinel(int offset, int stickGap) => offset == stickGap + 1 ? 0 : offset;
+
+    internal static int ConstrainResizeDimension(int value, int minimum, int maximum, int minimumTrack,
+        int maximumTrack)
+    {
+        if (maximum != 0)
+        {
+            value = Math.Min(value, maximum);
+        }
+
+        return Math.Max(Math.Max(Math.Min(value, maximumTrack), minimum), minimumTrack);
+    }
+
+    internal static Rectangle ComputeResizeOffsets(Rectangle bounds, Rectangle workingArea,
+        IEnumerable<Rectangle> otherWindows, ResizeDir direction, int stickGap, bool stickToScreen, bool stickToOther)
+    {
+        var offsets = new Rectangle(stickGap + 1, stickGap + 1, 0, 0);
+        if (stickToScreen)
+        {
+            offsets = ComputeResizeSnap(bounds, workingArea, offsets, direction, stickGap, false);
+        }
+
+        if (stickToOther)
+        {
+            foreach (var otherBounds in otherWindows)
+            {
+                offsets = ComputeResizeSnap(bounds, otherBounds, offsets, direction, stickGap, true);
+            }
+        }
+
+        return offsets;
     }
 
     /// <summary>
@@ -674,68 +624,39 @@ public sealed class StickyWindow : NativeWindow
     private void Move(Point p)
     {
         p = _originalForm.PointToScreen(p);
-        var activeScr = Screen.FromPoint(p); // get the screen from the point !!
-
-        if (!activeScr.WorkingArea.Contains(p))
-        {
-            p.X = NormalizeInside(p.X, activeScr.WorkingArea.Left, activeScr.WorkingArea.Right);
-            p.Y = NormalizeInside(p.Y, activeScr.WorkingArea.Top, activeScr.WorkingArea.Bottom);
-        }
-
-        p.Offset(-_offsetPoint.X, -_offsetPoint.Y);
-
-        // p is the exact location of the frame - so we can play with it
-        // to detect the new position according to different bounds
-        _formRect.Location = p; // this is the new position of the form
-
-        _formOffsetPoint.X = StickGap + 1; // (more than) maximum gaps
-        _formOffsetPoint.Y = StickGap + 1;
-
-        if (StickToScreen)
-        {
-            Move_Stick(activeScr.WorkingArea, false);
-        }
-
-        // Now try to snap to other windows
-        if (StickToOther)
-        {
-            foreach (var sw in _globalStickyWindows)
-            {
-                var form = sw as Form;
-                if (form == _originalForm)
-                {
-                    continue;
-                }
-
-                if (form != null)
-                {
-                    Move_Stick(form.Bounds, true);
-                }
-            }
-        }
-
-        if (_formOffsetPoint.X == StickGap + 1)
-        {
-            _formOffsetPoint.X = 0;
-        }
-
-        if (_formOffsetPoint.Y == StickGap + 1)
-        {
-            _formOffsetPoint.Y = 0;
-        }
-
-        _formRect.Offset(_formOffsetPoint);
-
+        _formRect = ComputeMoveBounds(_formRect, p, _offsetPoint, Screen.FromPoint(p).WorkingArea,
+            GetOtherWindowBounds(), StickGap, StickToScreen, StickToOther);
         _originalForm.Bounds = _formRect;
     }
 
-    /// <summary>
-    /// </summary>
-    /// <param name="toRect">Rect to try to snap to</param>
-    /// <param name="bInsideStick">Allow snapping on the inside (eg: window to screen)</param>
-    private void Move_Stick(Rectangle toRect, bool bInsideStick)
+    private IEnumerable<Rectangle> GetOtherWindowBounds() => _globalStickyWindows.OfType<Form>()
+        .Where(form => form != _originalForm).Select(form => form.Bounds);
+
+    internal static Rectangle ComputeMoveBounds(Rectangle bounds, Point mousePoint, Point mouseOffset,
+        Rectangle workingArea, IEnumerable<Rectangle> otherWindows, int stickGap, bool stickToScreen, bool stickToOther)
     {
-        _formOffsetPoint = ComputeMoveSnap(_formRect, toRect, _formOffsetPoint, StickGap, bInsideStick);
+        mousePoint.X = NormalizeInside(mousePoint.X, workingArea.Left, workingArea.Right);
+        mousePoint.Y = NormalizeInside(mousePoint.Y, workingArea.Top, workingArea.Bottom);
+        mousePoint.Offset(-mouseOffset.X, -mouseOffset.Y);
+        bounds.Location = mousePoint;
+
+        var offset = new Point(stickGap + 1, stickGap + 1);
+
+        if (stickToScreen)
+        {
+            offset = ComputeMoveSnap(bounds, workingArea, offset, stickGap, false);
+        }
+
+        if (stickToOther)
+        {
+            foreach (var otherBounds in otherWindows)
+            {
+                offset = ComputeMoveSnap(bounds, otherBounds, offset, stickGap, true);
+            }
+        }
+
+        bounds.Offset(ClearSnapSentinel(offset.X, stickGap), ClearSnapSentinel(offset.Y, stickGap));
+        return bounds;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Reduce the five highest CRAP hotspots by separating window and Outlook side effects from directly testable behavior.

- Extract resize stretching, size constraints, snap-offset accumulation, movement calculations, and resize hit-target mapping.
- Separate instance loading from single/multiple-instance menu configuration and unify show/hide updates.
- Add regression tests for menu transitions, repeated configuration, click handlers, visibility changes, window geometry, and enabled/disabled hit-target dispatch.
- Replace expression-only instance-count tests with tests of the production property using isolated registry keys.
- Preserve the existing order-dependent resize snapping behavior.

## CRAP Scores
Measured using a Release coverage run and the repository's ReportGenerator filters:

| Method | Before | After |
| --- | ---: | ---: |
| `LoadInstances()` | 2,550 | 20 |
| `Resize()` | 1,190 | 2 |
| `OnNCLButtonDown()` | 380 | 6 |
| `ShowHideAllInstances()` | 272 | 2 |
| `Move()` | 272 | 2 |

The remaining UI adapters are intentionally small; the extracted behavior has direct tests rather than merely moving uncovered complexity into other methods. No coverage exclusions were added.